### PR TITLE
adds type to substatements matches items property

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -516,6 +516,7 @@ components:
         matches:
           type: array
           items:
+            type: object
             properties:
               recommendationId:
                 type: string


### PR DESCRIPTION
This change generates a matches property with type of SubstatementsMatches[]:
```
export interface Substatements { 
    /**
     * UUID referring to
     */
    substatementId?: string;
    /**
     * this is the job description substatment text
     */
    substatement?: string;
    matches?: Array<SubstatementsMatches>;
}
```