### PR TITLE
Fix for client code generation

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -8,7 +8,7 @@ servers:
 info:
   description: |-
     This is a collection of schemas and endpoints for the various JDX, Concentric Sky facing REST endpoints, the schemas define an API contract of sorts between the request and response expectations of the JDX reference application. This API is to be mutually developed by Concentric Sky and BrightHive.
-  version: "0.0.4"
+  version: "0.0.6"
   title: JDX reference application API
   termsOfService: 'https://www.uschamberfoundation.org/workforce-development/JDX'
   contact:
@@ -48,7 +48,32 @@ paths:
           description: Validation error
         '500':
           description: Internal server error
-
+          
+  /preview:
+    post:
+      summary: Get preview of job description with tagged matches.
+      requestBody:
+        description: Get preview of job description wth tagged matches.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/request'
+      responses:
+        '200':
+          description: Provides a chunked job description with matches that refer to the given paragraph chunks.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/previewResponse'
+        '422':
+          $ref: '#/components/responses/422'
+        '400':
+          $ref: '#/components/responses/400'
+        '415':
+          $ref: '#/components/responses/415'
+        '503':
+          $ref: '#/components/responses/503'
+        
   /upload-job-description-context:
     post:
       summary: Provide job description context (e.g metadata) on the job description
@@ -392,7 +417,27 @@ components:
       allOf:
         - $ref: '#/components/schemas/response'
         - $ref: '#/components/schemas/jobDescriptionContextRequest'
-
+    
+    previewResponse:
+      allOf:
+        - $ref: '#/components/schemas/response'
+        - $ref: '#/components/schemas/previewObject'
+        
+    previewObject:
+      type: object
+      properties:
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/previewFields'
+        
+    previewFields:
+      type: object
+      properties:
+        field:
+          type: string
+          example: 
+    
     frameworkSelectionRequest:
       allOf:
         - $ref: '#/components/schemas/request'

--- a/spec.yaml
+++ b/spec.yaml
@@ -430,13 +430,25 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/previewFields'
+        paragraphs:
+          type: array
+          items:
+            $ref: '#/components/schemas/previewParagraphs'
         
     previewFields:
       type: object
       properties:
         field:
           type: string
-          example: 
+          example: (JobMaster).title
+        paragraph_number:
+          type: integer
+          example: 1
+    
+    previewParagraphs:
+      type: string
+      example: 'Posted on 4/2/2021 18:23:01'
+        
     
     frameworkSelectionRequest:
       allOf:

--- a/spec.yaml
+++ b/spec.yaml
@@ -399,24 +399,26 @@ components:
         - type: object
           properties:
             frameworks:
-              type: object
-              properties:
-                competency:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/framework'
-                occupation:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/framework'
-                industry:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/framework'
-                    
+              $ref: '#/components/schemas/frameworks'
+
+    frameworks:
+      type: object
+      properties:
+        competency:
+          type: array
+          items:
+            $ref: '#/components/schemas/framework'
+        occupation:
+          type: array
+          items:
+            $ref: '#/components/schemas/framework'
+        industry:
+          type: array
+          items:
+            $ref: '#/components/schemas/framework'
+
     frameworkSelectionResponse:
       $ref: '#/components/schemas/response'
-
 
     frameworkRecommendationResponse:
       allOf:


### PR DESCRIPTION
API client generator was producing an Array<any> for UserActionRequest.matchTableSelections. This causes it to generate a named type for that MatchTableSelection object.

Also fixes a property name typo.